### PR TITLE
feat: cache persistence, responsive fixes & Elao timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,56 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# polemil.dev
 
-## Getting Started
+My personal portfolio — a colorful, animated, interactive website built to showcase who I am, what I do, and what I love.
 
-First, run the development server:
+**[polemil.dev](https://polemil.dev)**
+
+## What's inside
+
+The site is split into distinct, color-coded sections that you navigate through like pages of a book:
+
+- **Profile** — a quick intro with an interactive profile card
+- **Projects** — a carousel of things I've built, with live links and tech breakdowns
+- **Timeline** — my professional journey from agency work to freelance
+- **Stack** — technologies, know-how, and soft skills organized in filterable tabs
+- **Hobbies** — a circular carousel of the things I enjoy outside of code (worldbuilding, writing, music, drawing, cooking...)
+- **Contact** — a form to reach me directly
+
+Every page has its own personality — background color, layout, and animations.
+
+## Built with
+
+- **Next.js 14** + **TypeScript** + **React 18**
+- **Tailwind CSS** + **SCSS** for styling
+- **Framer Motion** for page transitions and micro-interactions
+- **Lottie** for playful illustrated animations
+- **Apollo Client** + **GraphQL** to fetch content from a custom backend
+- **i18next** for internationalization (FR / EN / RU) with localStorage caching (stale-while-revalidate)
+- **React Slick** + **React Swipeable** for carousels and touch gestures
+
+## Highlights
+
+- Smooth page transitions with staggered animations
+- Swipe navigation on mobile
+- Hover effects everywhere — bubble bursts, tilt-shake, rotating borders, floating icons
+- Fully responsive with a mobile-first approach
+- Content served from a custom GraphQL API at `graphql.polemil.dev`
+
+## i18n caching
+
+Translations are fetched from the API and cached in the browser's localStorage via `i18next-chained-backend` + `i18next-localstorage-backend`. On subsequent visits, cached translations are served instantly while the app revalidates in the background after 24 hours.
+
+To clear the cache manually, remove `i18next_res_*` keys from localStorage in DevTools.
+
+## Running locally
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Then open [localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Author
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+**Polémil Moreau** — Front-end developer, freelance  
+[polemil.dev](https://polemil.dev)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cv",
+  "name": "polemil.dev",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -16,10 +16,13 @@
     "@apollo/experimental-nextjs-app-support": "^0.11.2",
     "@fontsource/material-icons": "^5.0.18",
     "@fontsource/material-icons-rounded": "^4.5.4",
+    "apollo3-cache-persist": "^0.15.0",
     "framer-motion": "^11.3.21",
     "graphql": "^16.9.0",
     "i18next": "^23.12.2",
+    "i18next-chained-backend": "^5.0.3",
     "i18next-http-backend": "^2.5.2",
+    "i18next-localstorage-backend": "^4.3.1",
     "lottie-react": "^2.4.0",
     "next": "^14.2.5",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fontsource/material-icons-rounded':
         specifier: ^4.5.4
         version: 4.5.4
+      apollo3-cache-persist:
+        specifier: ^0.15.0
+        version: 0.15.0(@apollo/client@3.14.0(@types/react@18.3.28)(graphql@16.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       framer-motion:
         specifier: ^11.3.21
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -29,9 +32,15 @@ importers:
       i18next:
         specifier: ^23.12.2
         version: 23.16.8
+      i18next-chained-backend:
+        specifier: ^5.0.3
+        version: 5.0.3
       i18next-http-backend:
         specifier: ^2.5.2
         version: 2.7.3
+      i18next-localstorage-backend:
+        specifier: ^4.3.1
+        version: 4.3.1
       lottie-react:
         specifier: ^2.4.0
         version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -48,8 +57,8 @@ importers:
         specifier: ^15.0.0
         version: 15.7.4(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react-slick:
-        specifier: ^0.31.0
-        version: 0.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.30.2
+        version: 0.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-swipeable:
         specifier: ^7.0.1
         version: 7.0.2(react@18.3.1)
@@ -581,6 +590,11 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apollo3-cache-persist@0.15.0:
+    resolution: {integrity: sha512-asxhPOHGddgXYvY4/Wa+XLODYpjci/kPB4zdy82D0tVGzVmvO4lqp3k06NtzHvd//gd9kCnTaG8iziwAcXZYjw==}
+    peerDependencies:
+      '@apollo/client': ^3.7.17
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -814,6 +828,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enquire.js@2.1.6:
+    resolution: {integrity: sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -1144,8 +1161,14 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
+  i18next-chained-backend@5.0.3:
+    resolution: {integrity: sha512-VUwc+yFpZzmIvtPfSdTv1+CjgZGZwGug6qHyIuSES/n7RDhVARFxthjML0anUMJVjlvLfRW/x6+U4UrxXBflmw==}
+
   i18next-http-backend@2.7.3:
     resolution: {integrity: sha512-FgZxrXdRA5u44xfYsJlEBL4/KH3f2IluBpgV/7riW0YW2VEyM8FzVt2XHAOi6id0Ppj7vZvCZVpp5LrGXnc8Ig==}
+
+  i18next-localstorage-backend@4.3.1:
+    resolution: {integrity: sha512-ry8WNBanUs55rsRZs9+xaZWRxCoTEMMOf+2vNSfzzJqDPbHaf0eMFMrtYp/2ocxU6Xrxfwz17Fdz0rSs3Kw39Q==}
 
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
@@ -1673,8 +1696,8 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-slick@0.31.0:
-    resolution: {integrity: sha512-zo6VLT8wuSBJffg/TFPbzrw2dEnfZ/cUKmYsKByh3AgatRv29m2LoFbq5vRMa3R3A4wp4d8gwbJKO2fWZFaI3g==}
+  react-slick@0.30.3:
+    resolution: {integrity: sha512-B4x0L9GhkEWUMApeHxr/Ezp2NncpGc+5174R02j+zFiWuYboaq98vmxwlpafZfMjZic1bjdIqqmwLDcQY0QaFA==}
     peerDependencies:
       react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2501,6 +2524,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apollo3-cache-persist@0.15.0(@apollo/client@3.14.0(@types/react@18.3.28)(graphql@16.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@apollo/client': 3.14.0(@types/react@18.3.28)(graphql@16.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -2755,6 +2782,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  enquire.js@2.1.6: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -3249,11 +3278,19 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
+  i18next-chained-backend@5.0.3:
+    dependencies:
+      '@babel/runtime': 7.28.6
+
   i18next-http-backend@2.7.3:
     dependencies:
       cross-fetch: 4.0.0
     transitivePeerDependencies:
       - encoding
+
+  i18next-localstorage-backend@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
 
   i18next@23.16.8:
     dependencies:
@@ -3761,9 +3798,10 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-slick@0.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-slick@0.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       classnames: 2.5.1
+      enquire.js: 2.1.6
       json2mq: 0.2.0
       lodash.debounce: 4.0.8
       react: 18.3.1

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -1,9 +1,33 @@
-import { ApolloClient, InMemoryCache } from "@apollo/client"
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/client"
+import { LocalStorageWrapper, persistCache } from "apollo3-cache-persist"
 import { GRAPHQL_URL } from "@/lib"
 
-const client = new ApolloClient({
-  uri: GRAPHQL_URL,
-  cache: new InMemoryCache(),
-})
+const cache = new InMemoryCache()
 
-export default client
+let client: ApolloClient<NormalizedCacheObject>
+
+export async function initApolloClient() {
+  if (typeof window !== "undefined") {
+    await persistCache({
+      cache,
+      storage: new LocalStorageWrapper(window.localStorage),
+      maxSize: 1048576, // 1MB
+    })
+  }
+
+  client = new ApolloClient({
+    uri: GRAPHQL_URL,
+    cache,
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: "cache-and-network",
+      },
+    },
+  })
+
+  return client
+}
+
+export default function getClient() {
+  return client
+}

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -36,7 +36,7 @@ export default function Tab({
     >
       <Link
         href={url}
-        className="py-2 px-4 md:gap-2 flex-1 flex flex-col xl:flex-row items-center justify-center"
+        className="py-1 lg:py-2 px-4 md:gap-2 flex-1 flex flex-col xl:flex-row items-center justify-center"
         tabIndex={index + 1}
       >
         <span className="material-icons group-hover:tilt-shake text-2xl lg:text-4xl">

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -34,7 +34,7 @@ export default function Tabs() {
       animate="show"
       className={cN(
         "tabs lg:px-8 shadow-around",
-        "flex lg:gap-x-12 justify-evenly lg:justify-between"
+        "flex lg:gap-x-0 justify-evenly lg:justify-between"
       )}
       {...swipeHandlers}
     >

--- a/src/features/Profile/ContactMe/ContactMe.tsx
+++ b/src/features/Profile/ContactMe/ContactMe.tsx
@@ -23,7 +23,7 @@ export default function ContactMe({ className }: WithClassNameProps) {
           initial={{ x: -80, y: 80, opacity: 0 }}
           animate={{ x: 0, y: 0, opacity: 1 }}
           transition={{ duration: 0.45, delay: 0.35 }}
-          className="material-icons font-bold text-4xl md:text-6xl lg:text-7xl group-hover:text-red-400 transition-all group-hover:![transform:translate(0.1em,-0.1em)]"
+          className="material-icons font-bold text-3xl md:text-6xl lg:text-7xl group-hover:text-red-400 transition-all group-hover:![transform:translate(0.1em,-0.1em)]"
         >
           north_east
         </m.span>

--- a/src/features/Profile/Digest/Digest.tsx
+++ b/src/features/Profile/Digest/Digest.tsx
@@ -16,7 +16,7 @@ export default function Digest({ className }: WithClassNameProps) {
       className={cN(
         className,
         "self-center sm:justify-center gap-2",
-        "font-rubikReg font-semibold text-xl md:text-2xl lg:text-3xl text-left mb-auto lg:mb-0"
+        "font-rubikReg font-semibold text-base sm:text-xl md:text-2xl lg:text-3xl text-left mb-auto lg:mb-0"
       )}
     >
       <m.h2
@@ -53,7 +53,7 @@ export default function Digest({ className }: WithClassNameProps) {
           informatique
         </m.div>
       </div>
-      <Feat.Links className="order-6 mt-8 mb-4 sm:mb-0 lg:mt-4" />
+      <Feat.Links className="order-6 mt-4 sm:mt-8 mb-4 sm:mb-0 lg:mt-4" />
       {/* <m.div
         variants={fadeInItem}
         className="order-2 lg:order-5 group-hover:push-forward mb-6 lg:mb-0"

--- a/src/features/Profile/Stats/Stats.tsx
+++ b/src/features/Profile/Stats/Stats.tsx
@@ -10,7 +10,7 @@ export default function Stats({ className }: WithClassNameProps) {
       variants={fadeInItem}
       className={cN(
         "stats grid template-[stats] lg:template-[stats-lg] w-full max-h-full lg:gap-x-12",
-        "pl-6 sm:px-[clamp(0rem,10vw,5rem)] lg:px-0 gap-y-6",
+        "pl-6 sm:px-[clamp(0rem,10vw,5rem)] lg:px-0 gap-y-3 sm:gap-y-6",
         className
       )}
     >

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,7 +6,7 @@ export const AUTHOR = {
   email: "contact@polemil.dev",
   url: "https://polemil.dev",
 }
-export const SITE_DESCRIPTION = `De son vrai nom ${AUTHOR.firstname} ${AUTHOR.lastname}, Polémil est un développeur Web Full-Stack spécialisé en React / TypeScript. Actuellement disponible pour vos offres de dev, voici mon CV en ligne. Découvrez mes compétences, mes projets, et mon parcours professionnel.`
+export const SITE_DESCRIPTION = `De son vrai nom ${AUTHOR.firstname} ${AUTHOR.lastname}, Polémil est un développeur Web Front-End spécialisé en React / TypeScript. Actuellement disponible pour vos offres de dev, voici mon CV en ligne. Découvrez mes compétences, mes projets, et mon parcours professionnel.`
 
 export const BO_URL = "https://bo.polemil.dev"
 export const API_URL = BO_URL + "/api"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,16 @@
 import { ApolloProvider } from "@apollo/client"
 import { AnimatePresence, motion as m } from "framer-motion"
 import i18n from "i18next"
-import Backend from "i18next-http-backend"
+import ChainedBackend from "i18next-chained-backend"
+import HttpBackend from "i18next-http-backend"
+import LocalStorageBackend from "i18next-localstorage-backend"
 import { AppProps } from "next/app"
 import Head from "next/head"
 import Link from "next/link"
+import { useEffect, useState } from "react"
 import { initReactI18next } from "react-i18next"
 
-import client from "@/apollo"
+import { initApolloClient } from "@/apollo"
 import usePreviousRoute from "@/hooks/usePreviousRoute"
 import { API_URL, AUTHOR, cN, SITE_DESCRIPTION, THUMBNAIL_URL } from "@/lib"
 import { IPageProps } from "@/types"
@@ -25,7 +28,7 @@ import "@/styles/transitions.scss"
 import "@fontsource/material-icons-rounded"
 
 i18n
-  .use(Backend)
+  .use(ChainedBackend)
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
     lng: "fr", // if you're using a language detector, do not define the lng option
@@ -36,13 +39,28 @@ i18n
     },
 
     backend: {
-      loadPath: `${API_URL}/i18n/{{lng}}`,
-      crossDomain: true,
+      backends: [LocalStorageBackend, HttpBackend],
+      backendOptions: [
+        {
+          expirationTime: 24 * 60 * 60 * 1000, // 24h cache
+        },
+        {
+          loadPath: `${API_URL}/i18n/{{lng}}`,
+          crossDomain: true,
+        },
+      ],
     },
   })
 
 function MyApp({ Component, pageProps, router }: AppProps<IPageProps>) {
   const previousRoute = usePreviousRoute()
+  const [client, setClient] = useState<Awaited<ReturnType<typeof initApolloClient>>>()
+
+  useEffect(() => {
+    initApolloClient().then(setClient)
+  }, [])
+
+  if (!client) return null
 
   return (
     <ApolloProvider client={client}>
@@ -119,7 +137,7 @@ function MyApp({ Component, pageProps, router }: AppProps<IPageProps>) {
           </AnimatePresence>
         </div>
 
-        <div className="flex items-center gap-x-12 lg:w-full absolute left-0 right-0 bottom-0 lg:sticky z-30 mb-4 lg:mb-0">
+        <div className="flex items-center gap-x-12 lg:w-full absolute left-0 right-0 bottom-0 lg:sticky z-30 mb-4 md:mb-2 lg:mb-0">
           <Logo className="hidden lg:flex" />
           <div className="flex-1">
             <Tabs />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,9 +24,9 @@ export default function Profile({ previousRoute }: IPageProps) {
         initial="hidden"
         animate="show"
         className={cN(
-          "grid gap-x-6 md:gap-x-10 gap-y-4 lg:gap-y-8 2xl:gap-y-10",
+          "grid gap-x-6 md:gap-x-10 gap-y-2 sm:gap-y-4 lg:gap-y-8 2xl:gap-y-10",
           "template-[base] sm:template-[sm] lg:template-[lg] 2xl:template-[2xl]",
-          "px-8 lg:px-[8vw] 2xl:px-[5rem] pb-8",
+          "px-4 sm:px-8 lg:px-[8vw] 2xl:px-[5rem] pb-8",
           "h-full overflow-y-auto no-scrollbar"
         )}
       >

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -42,8 +42,16 @@ const TMP_DATA = [
     id: "freelance",
     title: "Août 2023",
     subTitle: "Freelance",
-    length: "h-60 lg:h-52 lg:w-40",
+    length: "h-32 lg:h-52 lg:w-40",
     children: ["Nouvelle aventure ! Je me lance en freelance."],
+  },
+  {
+    id: "elao",
+    title: "Octobre 2024",
+    subTitle: "Lead développeur front-end",
+    length: "h-56 lg:h-52 lg:w-40",
+    children: ["J’intègre Elao et travaille sur plusieurs apps front (React, Astro) : santé, suivi du temps et usine à sites.",
+    "En parallèle, j’améliore le workflow design→dev grâce aux nouveaux outils IA (MCP Figma, Skills) et rédige des articles sur l’évolution du CSS."],
   },
 ]
 

--- a/src/styles/pages.scss
+++ b/src/styles/pages.scss
@@ -13,12 +13,12 @@
 
   /* prettier-ignore */
   --base:
-  	"pagetitle pagetitle" minmax(4rem, auto)
+  	"pagetitle pagetitle" minmax(2rem, auto)
   	"photo     .        "
   	"photo     name     "
-    "digest    digest   " 1fr
-    "mailBtn   mailBtn  "
-    "stats     stats    "
+    "digest    digest   " auto
+    "mailBtn   mailBtn  " auto
+    "stats     stats    " 1fr
   / auto 1fr;
 
   /* prettier-ignore */


### PR DESCRIPTION
## Summary
- **Apollo cache persistence** — queries are cached in localStorage via `apollo3-cache-persist` with a `cache-and-network` fetch policy for instant loads + background refresh
- **i18n translation caching** — chained backend (localStorage → HTTP) with 24h stale-while-revalidate, so translations load instantly on repeat visits
- **Mobile responsive fixes** — tighter gaps, padding, and font sizes on small screens across Profile, Tabs, Stats, Digest, ContactMe
- **New timeline entry** — Elao (Oct 2024), Lead front-end developer
- **README rewrite** — proper project description replacing the default Next.js boilerplate
- **SEO update** — description changed from "Full-Stack" to "Front-End"

## Test plan
- [ ] Verify site loads correctly on mobile and desktop
- [ ] Check localStorage contains Apollo cache and i18n entries after first load
- [ ] Confirm subsequent page loads are faster (cached data renders immediately)
- [ ] Verify Elao entry appears in the timeline
- [ ] Check responsive spacing on Profile page at various breakpoints
