### PR TITLE
fix: add nofollow on CV download link

### DIFF
--- a/src/features/Profile/Links/Links.tsx
+++ b/src/features/Profile/Links/Links.tsx
@@ -37,6 +37,7 @@ export default function Links({ className }: WithClassNameProps) {
         ref={ref}
         variants={fadeInItem}
         href={CV_URL}
+        rel="nofollow noopener noreferrer"
         target="_blank"
         className={cN(
           "relative group flex items-center justify-center w-full md:w-auto",


### PR DESCRIPTION
## Summary
- Add `rel="nofollow noopener noreferrer"` to the CV download link to prevent search engines from following and indexing the PDF URL

## Test plan
- [ ] Verify the CV download link still works correctly
- [ ] Inspect the rendered HTML to confirm `rel` attribute is present