### PR TITLE
chore: refresh profile stats counters

### DIFF
--- a/src/features/Profile/Stats/Stats.tsx
+++ b/src/features/Profile/Stats/Stats.tsx
@@ -17,21 +17,21 @@ export default function Stats({ className }: WithClassNameProps) {
       <Stat
         href="/timeline"
         countClassName="after:!text-indigo-400"
-        count={6}
+        count={8}
         text="ans d'expérience"
         className="area-[s1]"
       />
       <Stat
         href="/projects"
         countClassName="after:!text-purplish-600"
-        count={14}
+        count={20}
         text="projets web"
         className="area-[s2]"
       />
       <Stat
         href="/stack"
         countClassName="after:!text-blue-500"
-        count={22}
+        count={23}
         text="technos domptées"
         className="area-[s3]"
       />


### PR DESCRIPTION
## Summary
- Bump years of experience from 6 to 8
- Bump web projects count from 14 to 20
- Bump tamed technologies count from 22 to 23

## Test plan
- [ ] Visit the profile page and verify the three stat tiles show 8 / 20 / 23
- [ ] Confirm links still navigate to `/timeline`, `/projects`, `/stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)